### PR TITLE
feat: add spaceapi_validation_versions metric indicating all versions supported by an endpoint

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/robfig/cron v1.2.0
 	github.com/rs/cors v1.7.0
-	github.com/spaceapi-community/go-spaceapi-validator-client v0.0.0-20200104101806-0433af38010f
+	github.com/spaceapi-community/go-spaceapi-validator-client v1.2.0
 	goji.io v2.0.2+incompatible
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -73,6 +73,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaceapi-community/go-spaceapi-validator-client v0.0.0-20200104101806-0433af38010f h1:8HjPc6E2+qGxbJTEvEMbtbHEdpCx+2ind2Vio4OTN2M=
 github.com/spaceapi-community/go-spaceapi-validator-client v0.0.0-20200104101806-0433af38010f/go.mod h1:Ck0OJ8C10sWvtKTGD63n9A1qEETdJe0k0XLZFIOcbkw=
+github.com/spaceapi-community/go-spaceapi-validator-client v1.2.0 h1:ig3KxosKgCrRHZJcLeFf5GvJwl6j0O+/XDQO75TFioU=
+github.com/spaceapi-community/go-spaceapi-validator-client v1.2.0/go.mod h1:AerddkhNG7XdxqCcjK7P1bk1473uGCsqN81T8wuHY7E=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
As a developer of SpaceAPI client software, it is of interest to me to know which schema versions are supported by which endpoints.

The directory collector already has the `spaceapi_version` metric delivering an overall distribution of used versions. However, there is currently no metric telling me e.g. how many endpoints that still implement v0.13 are also compliant with v14.

This PR adds the `spaceapi_validation_version` gauge metric with a `version` label. The metric is set for each version indicated to be supported by the endpoint, as returned by the validator's `checkedVersions` key, e.g.:

```
spaceapi_validation_version{route="https://spaceapi.kabelsalat.ch/",version="13"} 1
spaceapi_validation_version{route="https://spaceapi.kabelsalat.ch/",version="14"} 1
spaceapi_validation_version{route="https://spaceapi.kabelsalat.ch/",version="15"} 1
```

This PR bumps the `github.com/spaceapi-community/go-spaceapi-validator-client` dependency from v1.1.0 to v1.2.0 to make use of the `checkedVersions` key that was introduced in this version.